### PR TITLE
fix: Port 4000 is already occupied

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.vscode-test
 /node_modules
 /out
+/yarn.lock

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "jekyll-run",
-	"version": "1.6.0",
+	"version": "1.7.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -2077,9 +2077,9 @@
 			"dev": true
 		},
 		"hosted-git-info": {
-			"version": "2.8.8",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+			"version": "2.8.9",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
 			"dev": true
 		},
 		"http-proxy-agent": {
@@ -3079,35 +3079,35 @@
 			"dev": true
 		},
 		"npm": {
-			"version": "7.20.6",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-7.20.6.tgz",
-			"integrity": "sha512-SRx0i1sMZDf8cd0/JokYD0EPZg0BS1iTylU9MSWw07N6/9CZHjMpZL/p8gsww7m2JsWAsTamhmGl15dQ9UgUgw==",
+			"version": "7.24.1",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-7.24.1.tgz",
+			"integrity": "sha512-U7/C++ZgB3zNH/kzhSJMnp3pO2iLrZRGUUXAgCCLB/by+sR+dKVhP/ik9+sTOGk9wk3zbmwHAYDT8igkv1ss0g==",
 			"dev": true,
 			"requires": {
-				"@npmcli/arborist": "^2.8.1",
+				"@npmcli/arborist": "^2.8.3",
 				"@npmcli/ci-detect": "^1.2.0",
-				"@npmcli/config": "^2.2.0",
+				"@npmcli/config": "^2.3.0",
 				"@npmcli/map-workspaces": "^1.0.4",
 				"@npmcli/package-json": "^1.0.1",
-				"@npmcli/run-script": "^1.8.5",
+				"@npmcli/run-script": "^1.8.6",
 				"abbrev": "~1.1.1",
 				"ansicolors": "~0.3.2",
 				"ansistyles": "~0.1.3",
 				"archy": "~1.0.0",
-				"cacache": "^15.2.0",
+				"cacache": "^15.3.0",
 				"chalk": "^4.1.2",
 				"chownr": "^2.0.0",
 				"cli-columns": "^3.1.2",
 				"cli-table3": "^0.6.0",
 				"columnify": "~1.5.4",
-				"glob": "^7.1.7",
+				"fastest-levenshtein": "^1.0.12",
+				"glob": "^7.2.0",
 				"graceful-fs": "^4.2.8",
 				"hosted-git-info": "^4.0.2",
 				"ini": "^2.0.0",
-				"init-package-json": "^2.0.3",
+				"init-package-json": "^2.0.5",
 				"is-cidr": "^4.0.2",
 				"json-parse-even-better-errors": "^2.3.1",
-				"leven": "^3.1.0",
 				"libnpmaccess": "^4.0.2",
 				"libnpmdiff": "^2.0.4",
 				"libnpmexec": "^2.0.1",
@@ -3119,7 +3119,7 @@
 				"libnpmsearch": "^3.1.1",
 				"libnpmteam": "^2.0.3",
 				"libnpmversion": "^1.2.1",
-				"make-fetch-happen": "^9.0.4",
+				"make-fetch-happen": "^9.1.0",
 				"minipass": "^3.1.3",
 				"minipass-pipeline": "^1.2.4",
 				"mkdirp": "^1.0.4",
@@ -3128,24 +3128,25 @@
 				"node-gyp": "^7.1.2",
 				"nopt": "^5.0.0",
 				"npm-audit-report": "^2.1.5",
+				"npm-install-checks": "^4.0.0",
 				"npm-package-arg": "^8.1.5",
 				"npm-pick-manifest": "^6.1.1",
 				"npm-profile": "^5.0.3",
 				"npm-registry-fetch": "^11.0.0",
 				"npm-user-validate": "^1.0.1",
-				"npmlog": "^5.0.0",
+				"npmlog": "^5.0.1",
 				"opener": "^1.5.2",
 				"pacote": "^11.3.5",
 				"parse-conflict-json": "^1.1.1",
 				"qrcode-terminal": "^0.12.0",
 				"read": "~1.0.7",
-				"read-package-json": "^3.0.1",
+				"read-package-json": "^4.1.1",
 				"read-package-json-fast": "^2.0.3",
 				"readdir-scoped-modules": "^1.1.0",
 				"rimraf": "^3.0.2",
 				"semver": "^7.3.5",
 				"ssri": "^8.0.1",
-				"tar": "^6.1.8",
+				"tar": "^6.1.11",
 				"text-table": "~0.2.0",
 				"tiny-relative-date": "^1.3.0",
 				"treeverse": "^1.0.4",
@@ -3154,8 +3155,13 @@
 				"write-file-atomic": "^3.0.3"
 			},
 			"dependencies": {
+				"@gar/promisify": {
+					"version": "1.1.2",
+					"bundled": true,
+					"dev": true
+				},
 				"@npmcli/arborist": {
-					"version": "2.8.1",
+					"version": "2.8.3",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -3188,7 +3194,6 @@
 						"rimraf": "^3.0.2",
 						"semver": "^7.3.5",
 						"ssri": "^8.0.1",
-						"tar": "^6.1.0",
 						"treeverse": "^1.0.4",
 						"walk-up-path": "^1.0.0"
 					}
@@ -3199,7 +3204,7 @@
 					"dev": true
 				},
 				"@npmcli/config": {
-					"version": "2.2.0",
+					"version": "2.3.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -3216,6 +3221,15 @@
 					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.3.0"
+					}
+				},
+				"@npmcli/fs": {
+					"version": "1.0.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@gar/promisify": "^1.0.1",
+						"semver": "^7.3.5"
 					}
 				},
 				"@npmcli/git": {
@@ -3299,13 +3313,12 @@
 					}
 				},
 				"@npmcli/run-script": {
-					"version": "1.8.5",
+					"version": "1.8.6",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"@npmcli/node-gyp": "^1.0.2",
 						"@npmcli/promise-spawn": "^1.3.2",
-						"infer-owner": "^1.0.4",
 						"node-gyp": "^7.1.0",
 						"read-package-json-fast": "^2.0.1"
 					}
@@ -3392,12 +3405,12 @@
 					"dev": true
 				},
 				"are-we-there-yet": {
-					"version": "1.1.5",
+					"version": "1.1.6",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
+						"readable-stream": "^3.6.0"
 					}
 				},
 				"asap": {
@@ -3479,10 +3492,11 @@
 					"dev": true
 				},
 				"cacache": {
-					"version": "15.2.0",
+					"version": "15.3.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
+						"@npmcli/fs": "^1.0.0",
 						"@npmcli/move-file": "^1.0.1",
 						"chownr": "^2.0.0",
 						"fs-minipass": "^2.0.0",
@@ -3780,6 +3794,11 @@
 					"bundled": true,
 					"dev": true
 				},
+				"fastest-levenshtein": {
+					"version": "1.0.12",
+					"bundled": true,
+					"dev": true
+				},
 				"forever-agent": {
 					"version": "0.6.1",
 					"bundled": true,
@@ -3828,7 +3847,7 @@
 					}
 				},
 				"glob": {
-					"version": "7.1.7",
+					"version": "7.2.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -3979,15 +3998,14 @@
 					"dev": true
 				},
 				"init-package-json": {
-					"version": "2.0.3",
+					"version": "2.0.5",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"glob": "^7.1.1",
-						"npm-package-arg": "^8.1.2",
+						"npm-package-arg": "^8.1.5",
 						"promzard": "^0.3.0",
 						"read": "~1.0.1",
-						"read-package-json": "^3.0.1",
+						"read-package-json": "^4.1.1",
 						"semver": "^7.3.5",
 						"validate-npm-package-license": "^3.0.4",
 						"validate-npm-package-name": "^3.0.0"
@@ -4012,7 +4030,7 @@
 					}
 				},
 				"is-core-module": {
-					"version": "2.5.0",
+					"version": "2.6.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -4030,11 +4048,6 @@
 					"dev": true
 				},
 				"is-typedarray": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"isarray": {
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true
@@ -4102,11 +4115,6 @@
 				},
 				"just-diff-apply": {
 					"version": "3.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"leven": {
-					"version": "3.1.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -4240,7 +4248,7 @@
 					}
 				},
 				"make-fetch-happen": {
-					"version": "9.0.4",
+					"version": "9.1.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -4258,7 +4266,7 @@
 						"minipass-pipeline": "^1.2.4",
 						"negotiator": "^0.6.2",
 						"promise-retry": "^2.0.1",
-						"socks-proxy-agent": "^5.0.0",
+						"socks-proxy-agent": "^6.0.0",
 						"ssri": "^8.0.0"
 					}
 				},
@@ -4284,7 +4292,7 @@
 					}
 				},
 				"minipass": {
-					"version": "3.1.3",
+					"version": "3.1.5",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -4300,7 +4308,7 @@
 					}
 				},
 				"minipass-fetch": {
-					"version": "1.3.4",
+					"version": "1.4.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -4459,12 +4467,12 @@
 					}
 				},
 				"normalize-package-data": {
-					"version": "3.0.2",
+					"version": "3.0.3",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"hosted-git-info": "^4.0.1",
-						"resolve": "^1.20.0",
+						"is-core-module": "^2.5.0",
 						"semver": "^7.3.4",
 						"validate-npm-package-license": "^3.0.1"
 					}
@@ -4557,14 +4565,25 @@
 					"dev": true
 				},
 				"npmlog": {
-					"version": "5.0.0",
+					"version": "5.0.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"are-we-there-yet": "^1.1.5",
+						"are-we-there-yet": "^2.0.0",
 						"console-control-strings": "^1.1.0",
 						"gauge": "^3.0.0",
 						"set-blocking": "^2.0.0"
+					},
+					"dependencies": {
+						"are-we-there-yet": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"delegates": "^1.0.0",
+								"readable-stream": "^3.6.0"
+							}
+						}
 					}
 				},
 				"number-is-nan": {
@@ -4644,11 +4663,6 @@
 					"bundled": true,
 					"dev": true
 				},
-				"path-parse": {
-					"version": "1.0.7",
-					"bundled": true,
-					"dev": true
-				},
 				"performance-now": {
 					"version": "2.1.0",
 					"bundled": true,
@@ -4656,11 +4670,6 @@
 				},
 				"proc-log": {
 					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"process-nextick-args": {
-					"version": "2.0.1",
 					"bundled": true,
 					"dev": true
 				},
@@ -4730,7 +4739,7 @@
 					"dev": true
 				},
 				"read-package-json": {
-					"version": "3.0.1",
+					"version": "4.1.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -4750,17 +4759,13 @@
 					}
 				},
 				"readable-stream": {
-					"version": "2.3.7",
+					"version": "3.6.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
 					}
 				},
 				"readdir-scoped-modules": {
@@ -4822,15 +4827,6 @@
 						}
 					}
 				},
-				"resolve": {
-					"version": "1.20.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"is-core-module": "^2.2.0",
-						"path-parse": "^1.0.6"
-					}
-				},
 				"retry": {
 					"version": "0.12.0",
 					"bundled": true,
@@ -4845,7 +4841,7 @@
 					}
 				},
 				"safe-buffer": {
-					"version": "5.1.2",
+					"version": "5.2.1",
 					"bundled": true,
 					"dev": true
 				},
@@ -4873,7 +4869,7 @@
 					"dev": true
 				},
 				"smart-buffer": {
-					"version": "4.1.0",
+					"version": "4.2.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -4887,13 +4883,13 @@
 					}
 				},
 				"socks-proxy-agent": {
-					"version": "5.0.0",
+					"version": "6.1.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"agent-base": "6",
-						"debug": "4",
-						"socks": "^2.3.3"
+						"agent-base": "^6.0.2",
+						"debug": "^4.3.1",
+						"socks": "^2.6.1"
 					}
 				},
 				"spdx-correct": {
@@ -4920,7 +4916,7 @@
 					}
 				},
 				"spdx-license-ids": {
-					"version": "3.0.9",
+					"version": "3.0.10",
 					"bundled": true,
 					"dev": true
 				},
@@ -4973,11 +4969,11 @@
 					}
 				},
 				"string_decoder": {
-					"version": "1.1.1",
+					"version": "1.3.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "~5.2.0"
 					}
 				},
 				"stringify-package": {
@@ -5002,7 +4998,7 @@
 					}
 				},
 				"tar": {
-					"version": "6.1.8",
+					"version": "6.1.11",
 					"bundled": true,
 					"dev": true,
 					"requires": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "jekyll-run",
 	"displayName": "Jekyll Run",
 	"description": "Build and Run your Jekyll static website",
-	"version": "1.6.0",
+	"version": "1.7.0",
 	"engines": {
 		"vscode": "^1.18.0"
 	},
@@ -18,7 +18,9 @@
 	],
 	"keywords": [
 		"Jekyll",
-		"run"
+		"run",
+		"vscode",
+		"extension"
 	],
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -174,6 +174,11 @@
 					"type": "string",
 					"description": "Command Line Arguments to be passed to `bundle exec jekyll serve` cmd",
 					"default": ""
+				},
+				"jekyll-run.stopServerOnExit": {
+					"type": "boolean",
+					"description": "Stop Jekyll server before exiting VS Code",
+					"default": "false"
 				}
 			}
 		}
@@ -204,6 +209,7 @@
 		"mocha": "^7.1.2",
 		"semantic-release": "^17.4.4",
 		"typescript": "^3.8.3",
+		"vsce": "^1.100.1",
 		"vscode-test": "^1.3.0"
 	},
 	"dependencies": {

--- a/src/cmds/run.ts
+++ b/src/cmds/run.ts
@@ -5,16 +5,17 @@ import {
   OutputChannel,
 } from 'vscode';
 import { spawn } from 'child_process';
-import { openLocalJekyllSite } from '../utils/open-in-browser';
+import { openUrl } from '../utils/open-in-browser';
 import { Stop } from './stop';
 import { Config } from '../config/config';
 
 export class Run {
   pid: number = 0;
   regenerateStatus = window.createStatusBarItem(StatusBarAlignment.Left, 497);
+  address: string = '';
   constructor() { }
 
-  async run(workspaceRootPath: string, portInConfig: number, baseurlInConfig: string, outputChannel: OutputChannel) {
+  async run(workspaceRootPath: string, serverPort: number, serverBaseurl: string, outputChannel: OutputChannel) {
     return await window.withProgress(
       {
         location: ProgressLocation.Notification,
@@ -44,8 +45,12 @@ export class Run {
             var strString = data.toString();
             outputChannel.append(strString);
             outputChannel.show(true);
+            if (strString.includes('Server address')) {
+              const match = strString.match(/Server address: (\S+)/m);
+              this.address = match ? match[1] : `http://localhost:${serverPort}`;
+            }
             if (strString.includes('Server running')) {
-              openLocalJekyllSite(portInConfig, baseurlInConfig);
+              openUrl(this.address);
               resolve(true);
             }
             else if (strString.includes('Regenerating')) {

--- a/src/cmds/run.ts
+++ b/src/cmds/run.ts
@@ -68,6 +68,11 @@ export class Run {
               this.regenerateStatus.hide();
               reject(data);
             }
+            if(error.includes('ruby')){
+              console.log('stderr: ' + data);
+              this.regenerateStatus.hide();
+              reject(error.match(/\B(.+)Errno(.+)/m));
+            }
           });
           child.on('close', (code) => {
             console.log('closing code: ' + code);

--- a/src/cmds/run.ts
+++ b/src/cmds/run.ts
@@ -47,7 +47,7 @@ export class Run {
             outputChannel.show(true);
             if (strString.includes('Server address')) {
               const match = strString.match(/Server address: (\S+)/m);
-              this.address = match ? match[1] : `http://localhost:${serverPort}`;
+              this.address = match?.[1]  || `http://localhost:${serverPort}`;
             }
             if (strString.includes('Server running')) {
               openUrl(this.address);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,16 +6,22 @@ import { lookpath } from './utils/look-path';
 import { Run } from './cmds/run';
 import { Build } from './cmds/build';
 import { Stop } from './cmds/stop';
-import { openUrl, openLocalJekyllSite } from './utils/open-in-browser';
+import { openUrl } from './utils/open-in-browser';
 import path = require('path');
 import { Install } from './cmds/install';
 import { findProcessOnPort } from './utils/process-on-port';
+import { Config } from './config/config';
 
 let currWorkspace: WorkspaceFolder | undefined;
 let pid: number = 0;
+let address: string = '';
 let isRunning = false;
 let portInConfig = 4000;
-let baseurlInConfig = '/';
+let portInArgs : number;
+let serverPort : number;
+let baseurlInConfig : string = '/';
+let baseurlInArgs : string;
+let serverBaseurl: string;
 
 let runButton: StatusBarItem | undefined;
 let stopButton: StatusBarItem | undefined;
@@ -34,6 +40,23 @@ enum Icons {
     Restart = "$(debug-restart)"
 }
 
+function getConfigFromArgs() {
+    const config = Config.get();
+    const args = config.commandLineArguments.toString();
+    const m_port = args.match(/\B(-P|--port)\s(\d+)\b/);
+    const m_baseurl = args.match(/\B(-b|--baseurl)\s(\S+)\b/);
+    if (m_port) {
+        portInArgs = parseInt(m_port[2]);
+    };
+    if (m_baseurl) {
+        baseurlInArgs = m_baseurl[2];
+    };
+    return { 
+        port: m_port ? true : false,
+        baseurl: m_baseurl ? true : false
+    };
+}
+
 function checkConfigAndGetPort(currWorkspace: WorkspaceFolder): boolean {
     const configPath = path.join(currWorkspace.uri.fsPath, '_config.yml');
     if (existsSync(configPath)) {
@@ -42,19 +65,11 @@ function checkConfigAndGetPort(currWorkspace: WorkspaceFolder): boolean {
 
         console.log(config);
         if (config.port !== undefined) { portInConfig = config.port; }
-        return true;
-    }
-    return false;
-}
-
-function checkConfigAndGetBaseUrl(currWorkspace: WorkspaceFolder): boolean {
-    const configPath = path.join(currWorkspace.uri.fsPath, '_config.yml');
-    if (existsSync(configPath)) {
-        var read = require('read-yaml');
-        var config = read.sync(configPath);
-
-        console.log(config);
         if (config.baseurl !== undefined) { baseurlInConfig = config.baseurl; }
+
+        const configInArgs = getConfigFromArgs();
+        serverPort = configInArgs.port? portInArgs : portInConfig;
+        serverBaseurl = configInArgs.baseurl? baseurlInArgs : baseurlInConfig;
         return true;
     }
     return false;
@@ -76,14 +91,12 @@ function isStaticWebsiteWorkspace(): boolean {
         if (resource.scheme === 'file') {
             currWorkspace = workspace.getWorkspaceFolder(resource);
             if (currWorkspace) {
-                checkConfigAndGetBaseUrl(currWorkspace);
                 return checkConfigAndGetPort(currWorkspace);
             }
         }
     } else {
         currWorkspace = workspace.workspaceFolders[0];
         if (currWorkspace) {
-            checkConfigAndGetBaseUrl(currWorkspace);
             return checkConfigAndGetPort(currWorkspace);
         }
     }
@@ -200,7 +213,7 @@ export function activate(context: ExtensionContext) {
 
     const open = commands.registerCommand('jekyll-run.Open', async () => {
         if (isStaticWebsiteWorkspace() && currWorkspace && isRunning) {
-            openLocalJekyllSite(portInConfig, baseurlInConfig);
+            openUrl(address);
         } else {
             window.showErrorMessage('No instance of Jekyll is running');
         }
@@ -214,7 +227,7 @@ export function activate(context: ExtensionContext) {
             runButton?.hide();
             outputChannel.appendLine('Checking if server is already running...');
             outputChannel.show(true);
-            var processOnPort = await findProcessOnPort(portInConfig);
+            var processOnPort = await findProcessOnPort(serverPort);
             if (processOnPort.pid !== 0) {
                 isRunning = true;
             }
@@ -224,13 +237,13 @@ export function activate(context: ExtensionContext) {
                         const run = new Run();
                         outputChannel.appendLine('Jekyll Building...');
                         outputChannel.show(true);
-                        run.run(currWorkspace.uri.fsPath, portInConfig, baseurlInConfig, outputChannel).
+                        run.run(currWorkspace.uri.fsPath, serverPort, serverBaseurl, outputChannel).
                             then((status) => {
                                 isRunning = true;
                                 commands.executeCommand('setContext', 'isRunning', true);
                                 if (status) {
                                     updateStatusBarItemsWhileRunning();
-                                    outputChannel.appendLine('Your site is live on port: ' + portInConfig);
+                                    outputChannel.appendLine('Your site is live on port: ' + serverPort);
                                     outputChannel.show(true);
                                 }
                                 else {
@@ -267,6 +280,7 @@ export function activate(context: ExtensionContext) {
                             }).
                             finally(() => {
                                 pid = run.pid;
+                                address = run.address;
                                 commands.executeCommand('setContext', 'isBuilding', false);
                             });
                     } else {
@@ -294,7 +308,7 @@ export function activate(context: ExtensionContext) {
                     pid = processOnPort.pid;
                     outputChannel.appendLine('Server is already running. Opening your site...');
                     outputChannel.show(true);
-                    openLocalJekyllSite(portInConfig, baseurlInConfig);
+                    openUrl(address);
                     isRunning = true;
                     commands.executeCommand('setContext', 'isRunning', true);
                     commands.executeCommand('setContext', 'isBuilding', false);
@@ -303,7 +317,7 @@ export function activate(context: ExtensionContext) {
                 else {
                     commands.executeCommand('setContext', 'isBuilding', false);
                     runButton?.show();
-                    window.showErrorMessage('Port ' + portInConfig + ' is already occupied by process: ' + processOnPort.pid + ' Either kill that process or use another port in _config.yml');
+                    window.showErrorMessage('Port ' + serverPort + ' is already occupied by process: ' + processOnPort.pid + ' Either kill that process or use another port in _config.yml');
                 }
             }
         } else {
@@ -396,7 +410,7 @@ export function activate(context: ExtensionContext) {
             openInBrowserButton?.dispose();
             commands.executeCommand('setContext', 'isBuilding', true);
             const run = new Run();
-            run.run(currWorkspace.uri.fsPath, portInConfig, baseurlInConfig, outputChannel).
+            run.run(currWorkspace.uri.fsPath, serverPort, serverBaseurl, outputChannel).
                 then(() => {
                     isRunning = true;
                     commands.executeCommand('setContext', 'isRunning', true);
@@ -429,6 +443,7 @@ export function activate(context: ExtensionContext) {
                 }).
                 finally(() => {
                     pid = run.pid;
+                    address = run.address;
                     commands.executeCommand('setContext', 'isBuilding', false);
                 });
         } else {
@@ -452,4 +467,17 @@ export function activate(context: ExtensionContext) {
 }
 
 // this method is called when your extension is deactivated
-export function deactivate() { }
+export function deactivate() {
+    console.log("Exit VSCode. Stopping: " + pid);
+    if (currWorkspace && isRunning) {
+        const stop = new Stop();
+        stop.Stop(pid, outputChannel).then(() => {
+            isRunning = false;
+            commands.executeCommand('setContext', 'isRunning', false);
+            commands.executeCommand('setContext', 'isBuilding', false);
+            revertStatusBarItems();
+        });
+    } else {
+        window.showErrorMessage('No instance of Jekyll is running');
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -67,9 +67,9 @@ function checkConfigAndGetPort(currWorkspace: WorkspaceFolder): boolean {
         if (config.port !== undefined) { portInConfig = config.port; }
         if (config.baseurl !== undefined) { baseurlInConfig = config.baseurl; }
 
-        const configInArgs = getConfigFromArgs();
-        serverPort = configInArgs.port? portInArgs : portInConfig;
-        serverBaseurl = configInArgs.baseurl? baseurlInArgs : baseurlInConfig;
+        getConfigFromArgs();
+        serverPort = portInArgs || portInConfig;
+        serverBaseurl = baseurlInArgs || baseurlInConfig;
         return true;
     }
     return false;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,10 +51,6 @@ function getConfigFromArgs() {
     if (m_baseurl) {
         baseurlInArgs = m_baseurl[2];
     };
-    return { 
-        port: m_port ? true : false,
-        baseurl: m_baseurl ? true : false
-    };
 }
 
 function checkConfigAndGetPort(currWorkspace: WorkspaceFolder): boolean {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,7 +93,7 @@ function isStaticWebsiteWorkspace(): boolean {
     } else {
         currWorkspace = workspace.workspaceFolders[0];
         if (currWorkspace) {
-            return checkConfigAndGetPort(currWorkspace);
+            return getPortAndBaseurl(currWorkspace);
         }
     }
     return false;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ import { Config } from './config/config';
 
 let currWorkspace: WorkspaceFolder | undefined;
 let pid: number = 0;
-let address: string = '';
+let address: string;
 let isRunning = false;
 let portInConfig = 4000;
 let portInArgs : number;
@@ -464,16 +464,9 @@ export function activate(context: ExtensionContext) {
 
 // this method is called when your extension is deactivated
 export function deactivate() {
-    console.log("Exit VSCode. Stopping: " + pid);
-    if (currWorkspace && isRunning) {
-        const stop = new Stop();
-        stop.Stop(pid, outputChannel).then(() => {
-            isRunning = false;
-            commands.executeCommand('setContext', 'isRunning', false);
-            commands.executeCommand('setContext', 'isBuilding', false);
-            revertStatusBarItems();
-        });
-    } else {
-        window.showErrorMessage('No instance of Jekyll is running');
+    const config = Config.get();
+    if (config.stopServerOnExit) {
+        console.log("Exit VSCode. Stopping: " + pid);
+        commands.executeCommand('jekyll-run.Stop');
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -87,7 +87,7 @@ function isStaticWebsiteWorkspace(): boolean {
         if (resource.scheme === 'file') {
             currWorkspace = workspace.getWorkspaceFolder(resource);
             if (currWorkspace) {
-                return checkConfigAndGetPort(currWorkspace);
+                return getPortAndBaseurl(currWorkspace);
             }
         }
     } else {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,7 +53,7 @@ function getConfigFromArgs() {
     };
 }
 
-function checkConfigAndGetPort(currWorkspace: WorkspaceFolder): boolean {
+function getPortAndBaseurl(currWorkspace: WorkspaceFolder): boolean {
     const configPath = path.join(currWorkspace.uri.fsPath, '_config.yml');
     if (existsSync(configPath)) {
         var read = require('read-yaml');

--- a/src/utils/open-in-browser.ts
+++ b/src/utils/open-in-browser.ts
@@ -9,11 +9,16 @@ export function openUrl(url: string = 'http://127.0.0.1') {
     }
 }
 
-export function openLocalJekyllSite(port: number = 4000, baseurl: string = '') {
-    let path = baseurl.replace(/^\/?(\S+[^\/]|\S+)(\/?)$/, '/$1/');
-    if (compareVersions.compare(version, '1.31', '<')) {
-        commands.executeCommand('vscode.open', Uri.parse('http://127.0.0.1:' + port + path));
-    } else {
-        env.openExternal(Uri.parse('http://127.0.0.1:' + port + path));
-    }
-}
+/**
+ * Deprecated from v1.7.0,
+ * @param port 
+ * @param baseurl 
+ */
+// export function openLocalJekyllSite(port: number = 4000, baseurl: string = '') {
+//     let path = baseurl.replace(/^\/?(\S+[^\/]|\S+)(\/?)$/, '/$1/');
+//     if (compareVersions.compare(version, '1.31', '<')) {
+//         commands.executeCommand('vscode.open', Uri.parse('http://127.0.0.1:' + port + path));
+//     } else {
+//         env.openExternal(Uri.parse('http://127.0.0.1:' + port + path));
+//     }
+// }

--- a/src/utils/open-in-browser.ts
+++ b/src/utils/open-in-browser.ts
@@ -1,7 +1,7 @@
 import compareVersions = require("compare-versions");
 import { version, commands, Uri, env } from "vscode";
 
-export function openUrl(url: string = 'http://127.0.0.1') {
+export function openUrl(url: string = 'http://127.0.0.1:4000') {
     if (compareVersions.compare(version, '1.31', '<')) {
         commands.executeCommand('vscode.open', Uri.parse(url));
     } else {


### PR DESCRIPTION
This PR fixes #29 with the following changes:

- Stop Jekyll server before exiting VS Code within `deactivate()`.
- Enable user easily changes the port and the base URL configuration in the extension settings.
- Deprecated `openLocalJekyllSite()` in `open-in-browser.ts`
- Changed to get the server address (_including the **port** and **base URL**_) from stdout.
- Replaced `openLocalJekyllSite()` with `openUrl()`